### PR TITLE
Skipping Packages, if resource does not exist

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -479,9 +479,8 @@ runs:
                 echo "Successfully installed terminology package '$packageName' in version '$packageVersion' from ZTS registry"
                 
               else
-                echo "Failed to download terminology package '$packageName' in version '$packageVersion'."
-                [[ -e "$packageFile" ]] && rm "$packageFile"
-                exit 1
+                echo "WARNING: Failed to download terminology package '$packageName' in version '$packageVersion'."
+                [[ -e "$packageFile" ]] && rm -f "$packageFile"
               fi
             done
           


### PR DESCRIPTION
When a Package does not exist on ZTS (e.g. KDL 2025.0.1), just continue with the processing